### PR TITLE
 add: nutzboot-starter-hystrix 支持@HystrixCommand和/hystrix.stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,19 +129,14 @@ public class MainLauncher {
     - [x] 基础框架的文档
     - [x] 基本框架的实现
 - 服务器类启动器
-    - web类启动器
+    - Servlet容器
         - [x] [Jetty](https://www.eclipse.org/jetty/)
         - [x] [Undertow](http://undertow.io/) by [@qinerg](https://github.com/qinerg)
         - [x] [Tomcat](http://tomcat.apache.org/) by [@benjobs](https://github.com/wolfboys)
-    - 非Web类启动器
+    - 非Web启动器
         - [ ] [netty](https://netty.io/)
         - [ ] [mina](https://mina.apache.org/)
         - [ ] [t-io](http://www.oschina.net/p/t-io)
-    - Rpc类启动器
-        - [x] [Dubbo](http://dubbo.io/) 阿里出品的高性能RPC平台
-        - [x] [zbus](http://zbus.io) 国产知名RPC平台
-        - [x] [feign](https://github.com/OpenFeign/feign) by [haoqoo](https://github.com/haoqoo) and [wendal](https://github.com/wendal)
-        - [ ] [motan](https://github.com/weibocom/motan)
     - 其他
         - [x] Ngrok 内网穿透,轻松获取外网地址
 - 数据库类相关
@@ -164,6 +159,15 @@ public class MainLauncher {
 - Mvc
     - [x] Nutz.Mvc
     - [ ] [jersey](https://jersey.github.io/)
+- 分布式组件
+	- RPC(Remote Procedure Call)
+		- [x] [Dubbo](http://dubbo.io/) 阿里出品的高性能RPC平台
+		- [x] [zbus](http://zbus.io) 国产知名RPC平台
+		- [ ] [motan](https://github.com/weibocom/motan)
+		- [x] [feign](https://github.com/OpenFeign/feign) by [haoqoo](https://github.com/haoqoo) and [wendal](https://github.com/wendal)
+		- [ ] [ribbon](https://github.com/Netflix/ribbon)
+    - [x] zkclient zookeeper的封装
+    - [x] [hystrix](https://github.com/Netflix/Hystrix) 熔断器
 - 安全鉴权
     - [x] [Shiro](http://shiro.apache.org)
 - 分布式Session
@@ -174,8 +178,8 @@ public class MainLauncher {
     - [x] [Beetl](http://ibeetl.com/) 
     - [x] [jetbrick-template](https://github.com/subchen/jetbrick-template-2x)
     - [x] Velocity by [haoqoo](https://github.com/haoqoo)
-    - [ ] FreeMarker
     - [x] Thymeleaf by [温泉](https://github.com/ywjno)
+    - [ ] FreeMarker
 - 消息队列
     - [x] disque redis作者的另一作品
     - [ ] zeromq
@@ -206,8 +210,6 @@ public class MainLauncher {
     - [ ] docker compose配置
 - WebService
     - [x] CXF
-- 分布式组件
-    - [x] zkclient zookeeper的封装
 ## 第三方starter或项目
 
 期待您的到来,报个issue告知一下吧 ^_^

--- a/nutzboot-demo/nutzboot-demo-simple/nutzboot-demo-simple-hystrix/pom.xml
+++ b/nutzboot-demo/nutzboot-demo-simple/nutzboot-demo-simple-hystrix/pom.xml
@@ -1,0 +1,59 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.nutz</groupId>
+    <artifactId>nutzboot-demo-simple</artifactId>
+    <version>2.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>nutzboot-demo-simple-hystrix</artifactId>
+  	<dependencies>
+		<dependency>
+			<groupId>org.nutz</groupId>
+			<artifactId>nutzboot-starter-nutz-mvc</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.nutz</groupId>
+			<artifactId>nutzboot-starter-jetty</artifactId>
+		</dependency>
+       	<dependency>
+			<groupId>org.nutz</groupId>
+			<artifactId>nutzboot-starter-hystrix</artifactId>
+		</dependency>
+       	<dependency>
+			<groupId>org.nutz</groupId>
+			<artifactId>nutzboot-starter-swagger</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-log4j12</artifactId>
+		</dependency>
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>3.0.0</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+								<transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+									<resource>META-INF/nutz/org.nutz.boot.starter.NbStarter</resource>
+								</transformer>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<mainClass>io.nutz.demo.simple.MainLauncher</mainClass>
+								</transformer>
+							</transformers>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/nutzboot-demo/nutzboot-demo-simple/nutzboot-demo-simple-hystrix/src/main/java/io/nutz/demo/simple/MainLauncher.java
+++ b/nutzboot-demo/nutzboot-demo-simple/nutzboot-demo-simple-hystrix/src/main/java/io/nutz/demo/simple/MainLauncher.java
@@ -1,0 +1,32 @@
+package io.nutz.demo.simple;
+
+import org.nutz.boot.NbApp;
+import org.nutz.ioc.loader.annotation.IocBean;
+import org.nutz.mvc.annotation.At;
+import org.nutz.mvc.annotation.Ok;
+
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+
+@Api("time")
+@IocBean(create = "init")
+public class MainLauncher {
+	
+    @ApiOperation(value = "获取当前毫秒数", notes="获取当前毫秒数", httpMethod="GET", response=Long.class)
+    @HystrixCommand
+	@At("/time/now")
+    @Ok("raw")
+	public long now() {
+	    return System.currentTimeMillis();
+	}
+    
+    public void init() {
+        now();
+    }
+
+	public static void main(String[] args) {
+		new NbApp().setPrintProcDoc(true).run();
+	}
+}

--- a/nutzboot-demo/nutzboot-demo-simple/nutzboot-demo-simple-hystrix/src/main/resources/log4j.properties
+++ b/nutzboot-demo/nutzboot-demo-simple/nutzboot-demo-simple-hystrix/src/main/resources/log4j.properties
@@ -1,0 +1,8 @@
+log4j.rootLogger=info,Console
+
+log4j.logger.org.nutz.mvc=debug
+log4j.logger.org.eclipse.jetty=info
+
+log4j.appender.Console=org.apache.log4j.ConsoleAppender
+log4j.appender.Console.layout=org.apache.log4j.PatternLayout
+log4j.appender.Console.layout.ConversionPattern=[%d{yyyy-MM-dd HH:mm:ss.SSS}] %5p [%t] --- %c{1}: %m%n

--- a/nutzboot-demo/nutzboot-demo-simple/nutzboot-demo-simple-hystrix/src/main/resources/static/index.html
+++ b/nutzboot-demo/nutzboot-demo-simple/nutzboot-demo-simple-hystrix/src/main/resources/static/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Hello, So NB!</title>
+</head>
+<body>
+	<div>
+		<h2>Hello, So NB!</h2>
+	</div>
+	<div>
+		<h2>
+			<a href="hystrix.stream">查看hystrix.stream</a>
+		</h2>
+	</div>
+	<div>
+		<h2>
+			<a href="swagger/index.html">查看api文档(由Swagger生成)</a>
+		</h2>
+	</div>
+</body>
+</html>

--- a/nutzboot-demo/nutzboot-demo-simple/nutzboot-demo-simple-velocity/pom.xml
+++ b/nutzboot-demo/nutzboot-demo-simple/nutzboot-demo-simple-velocity/pom.xml
@@ -22,7 +22,6 @@
         <dependency>
             <groupId>org.nutz</groupId>
             <artifactId>nutzboot-starter-velocity</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/nutzboot-demo/nutzboot-demo-simple/nutzboot-demo-simple-zkclient/pom.xml
+++ b/nutzboot-demo/nutzboot-demo-simple/nutzboot-demo-simple-zkclient/pom.xml
@@ -7,13 +7,13 @@
   </parent>
   <artifactId>nutzboot-demo-simple-zkclient</artifactId>
   	<dependencies>
-		<dependency>
-			<groupId>org.nutz</groupId>
-			<artifactId>nutzboot-starter-nutz-mvc</artifactId>
-		</dependency>
        	<dependency>
 			<groupId>org.nutz</groupId>
 			<artifactId>nutzboot-starter-zkclient</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-log4j12</artifactId>
 		</dependency>
 	</dependencies>
 	<build>

--- a/nutzboot-demo/nutzboot-demo-simple/pom.xml
+++ b/nutzboot-demo/nutzboot-demo-simple/pom.xml
@@ -31,7 +31,8 @@
 		<module>nutzboot-demo-simple-jetty</module>
         
         <module>nutzboot-demo-simple-caffeine</module>
-    </modules>
+        <module>nutzboot-demo-simple-hystrix</module>
+	</modules>
 
 	<dependencies>
 		<dependency>

--- a/nutzboot-starter-feign/pom.xml
+++ b/nutzboot-starter-feign/pom.xml
@@ -41,7 +41,6 @@
         <dependency>
             <groupId>io.github.openfeign</groupId>
             <artifactId>feign-hystrix</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.github.openfeign</groupId>

--- a/nutzboot-starter-feign/src/main/java/org/nutz/boot/starter/feign/FeignStarter.java
+++ b/nutzboot-starter-feign/src/main/java/org/nutz/boot/starter/feign/FeignStarter.java
@@ -11,17 +11,22 @@ import org.nutz.ioc.loader.annotation.Inject;
 import org.nutz.ioc.loader.annotation.IocBean;
 import org.nutz.lang.Strings;
 
+import feign.Client;
 import feign.Feign;
+import feign.Logger;
 import feign.Logger.Level;
+import feign.codec.Decoder;
+import feign.codec.Encoder;
 import feign.gson.GsonDecoder;
 import feign.gson.GsonEncoder;
 import feign.httpclient.ApacheHttpClient;
+import feign.hystrix.FallbackFactory;
+import feign.hystrix.HystrixFeign;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
 import feign.jaxb.JAXBContextFactory;
 import feign.jaxb.JAXBDecoder;
 import feign.jaxb.JAXBEncoder;
-import feign.jaxrs.JAXRSContract;
 import feign.okhttp.OkHttpClient;
 import feign.ribbon.RibbonClient;
 import feign.slf4j.Slf4jLogger;
@@ -43,11 +48,14 @@ public class FeignStarter implements IocEventListener {
     @PropDoc(value = "WebService的schema地址")
     public static final String PROP_SCHEMA = PRE + "schema";
 
-    @PropDoc(value = "默认编码器", possible= {"raw", "nutzjson", "jackson", "gson", "jaxb", "jaxrs"})
+    @PropDoc(value = "默认编码器", possible = {"raw", "nutzjson", "jackson", "gson", "jaxb", "jaxrs"})
     public static final String PROP_ENCODER = PRE + "encoder";
 
-    @PropDoc(value = "默认解码器", possible= {"raw", "nutzjson", "jackson", "gson", "jaxb", "jaxrs"})
+    @PropDoc(value = "默认解码器", possible = {"raw", "nutzjson", "jackson", "gson", "jaxb", "jaxrs"})
     public static final String PROP_DECODER = PRE + "decoder";
+
+    @PropDoc(value = "是否使用Hystrix", defaultValue = "false", possible = {"true", "false"})
+    public static final String PROP_USE_HYSTRIX = PRE + "useHystrix";
 
     @Inject("refer:$ioc")
     protected Ioc ioc;
@@ -55,80 +63,38 @@ public class FeignStarter implements IocEventListener {
     @Inject
     protected PropertiesProxy conf;
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public Object afterBorn(Object obj, String beanName) {
         try {
             for (Field field : obj.getClass().getDeclaredFields()) {
                 FeignInject fc = field.getAnnotation(FeignInject.class);
                 if (fc == null)
                     continue;
-                Feign.Builder builder = Feign.builder();
-                switch (Strings.sBlank(fc.encoder(), conf.get(PROP_ENCODER, ""))) {
-                case "":
-                case "raw":
-                    break;
-                case "nutzjson":
-                    builder.encoder(new NutzJsonEncoder());
-                    break;
-                case "jackson":
-                    builder.encoder(new JacksonEncoder());
-                    break;
-                case "gson":
-                    builder.encoder(new GsonEncoder());
-                    break;
-                case "jaxb":
-                    JAXBContextFactory jaxbFactory = new JAXBContextFactory.Builder().withMarshallerJAXBEncoding("UTF-8").withMarshallerSchemaLocation(fc.schema()).build();
-                    builder.encoder(new JAXBEncoder(jaxbFactory));
-                    break;
-                case "jaxrs":
-                    builder.contract(new JAXRSContract());
-                    break;
-                default:
-                    break;
-                }
-                switch (Strings.sBlank(fc.decoder(), conf.get(PROP_DECODER, ""))) {
-                case "":
-                case "raw":
-                    break;
-                case "nutzjson":
-                    builder.decoder(new NutzJsonDecoder());
-                    break;
-                case "jackson":
-                    builder.decoder(new JacksonDecoder());
-                    break;
-                case "gson":
-                    builder.decoder(new GsonDecoder());
-                    break;
-                case "jaxb":
-                    JAXBContextFactory jaxbFactory = new JAXBContextFactory.Builder().withMarshallerJAXBEncoding("UTF-8")
-                                                                                     .withMarshallerSchemaLocation(Strings.sBlank(fc.schema(), conf.get(PROP_SCHEMA)))
-                                                                                     .build();
-                    builder.decoder(new JAXBDecoder(jaxbFactory));
-                    break;
-                case "jaxrs":
-                    builder.contract(new JAXRSContract());
-                    break;
-                default:
-                    break;
-                }
-                switch (Strings.sBlank(fc.client(), conf.get(PROP_CLIENT, "jdk"))) {
-                case "jdk":
-                    // nop
-                    break;
-                case "okhttp":
-                    builder.client(new OkHttpClient());
-                    break;
-                case "httpclient":
-                    builder.client(new ApacheHttpClient());
-                    break;
-                case "ribbon":
-                    builder.client(RibbonClient.create());
-                    break;
-                default:
-                    break;
-                }
-                builder.logger(new Slf4jLogger());
-                builder.logLevel(Level.valueOf(conf.get(PROP_LOGLEVEL, "BASIC").toUpperCase()));
-                Object t = builder.target(field.getType(), Strings.sBlank(conf.get(PROP_URL), "http://127.0.0.1:8080"));
+                Encoder encoder = getEncoder(fc, field);
+                Decoder decoder = getDecoder(fc, field);
+                Client client = getClient(fc, field);
+                Logger.Level level = Level.valueOf(conf.get(PROP_LOGLEVEL, "BASIC").toUpperCase());
+                String url = Strings.sBlank(conf.get(PROP_URL), "http://127.0.0.1:8080");
+                Class<?> apiType = field.getType();
+                Logger logger = new Slf4jLogger(apiType);
+
+                boolean useHystrix = "true".equals(Strings.sBlank(fc.useHystrix(), conf.get(PROP_USE_HYSTRIX)));
+                Feign.Builder builder = useHystrix ? HystrixFeign.builder() : Feign.builder();
+                if (encoder != null)
+                    builder.encoder(encoder);
+                if (decoder != null)
+                    builder.decoder(decoder);
+                if (client != null)
+                    builder.client(client);
+                builder.logger(logger);
+                builder.logLevel(level);
+                Object t = useHystrix ? ((HystrixFeign.Builder) builder).target(apiType, url, new FallbackFactory() {
+                    public Object create(Throwable cause) {
+                        if (Strings.isBlank(fc.fallback()))
+                            return ioc.getByType(apiType);
+                        return ioc.get(apiType, fc.fallback());
+                    }
+                }) : builder.target(apiType, url);
                 field.setAccessible(true);
                 field.set(obj, t);
             }
@@ -147,4 +113,63 @@ public class FeignStarter implements IocEventListener {
         return 0;
     }
 
+    protected Decoder getDecoder(FeignInject fc, Field field) {
+
+        switch (Strings.sBlank(fc.decoder(), conf.get(PROP_DECODER, ""))) {
+        case "":
+        case "raw":
+            break;
+        case "nutzjson":
+            return new NutzJsonDecoder();
+        case "jackson":
+            return new JacksonDecoder();
+        case "gson":
+            return new GsonDecoder();
+        case "jaxb":
+            JAXBContextFactory jaxbFactory = new JAXBContextFactory.Builder().withMarshallerJAXBEncoding("UTF-8")
+                                                                             .withMarshallerSchemaLocation(Strings.sBlank(fc.schema(), conf.get(PROP_SCHEMA)))
+                                                                             .build();
+            return new JAXBDecoder(jaxbFactory);
+        default:
+            break;
+        }
+        return null;
+    }
+
+    protected Encoder getEncoder(FeignInject fc, Field field) {
+        switch (Strings.sBlank(fc.encoder(), conf.get(PROP_ENCODER, ""))) {
+        case "":
+        case "raw":
+            break;
+        case "nutzjson":
+            return new NutzJsonEncoder();
+        case "jackson":
+            return new JacksonEncoder();
+        case "gson":
+            return new GsonEncoder();
+        case "jaxb":
+            JAXBContextFactory jaxbFactory = new JAXBContextFactory.Builder().withMarshallerJAXBEncoding("UTF-8").withMarshallerSchemaLocation(fc.schema()).build();
+            return new JAXBEncoder(jaxbFactory);
+        default:
+            break;
+        }
+        return null;
+    }
+
+    protected Client getClient(FeignInject fc, Field field) {
+        switch (Strings.sBlank(fc.client(), conf.get(PROP_CLIENT, "jdk"))) {
+        case "jdk":
+            // nop
+            break;
+        case "okhttp":
+            return new OkHttpClient();
+        case "httpclient":
+            return new ApacheHttpClient();
+        case "ribbon":
+            return RibbonClient.create();
+        default:
+            break;
+        }
+        return null;
+    }
 }

--- a/nutzboot-starter-feign/src/main/java/org/nutz/boot/starter/feign/annotation/FeignInject.java
+++ b/nutzboot-starter-feign/src/main/java/org/nutz/boot/starter/feign/annotation/FeignInject.java
@@ -19,11 +19,15 @@ public @interface FeignInject {
     String encoder() default "";
 
     String decoder() default "";
-    
+
     /**
      * JAXB作为编码/解码器的时候必须填写
      */
     String schema() default "";
-    
+
     String client() default "";
+
+    String useHystrix() default "";
+
+    String fallback() default "";
 }

--- a/nutzboot-starter-hystrix/pom.xml
+++ b/nutzboot-starter-hystrix/pom.xml
@@ -1,0 +1,37 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.nutz</groupId>
+    <artifactId>nutzboot-parent</artifactId>
+    <version>2.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>nutzboot-starter-hystrix</artifactId>
+  <dependencies>
+  	<dependency>
+  		<groupId>org.nutz</groupId>
+  		<artifactId>nutzboot-starter</artifactId>
+  	</dependency>
+  	<dependency>
+  		<groupId>com.netflix.hystrix</groupId>
+  		<artifactId>hystrix-request-servlet</artifactId>
+  	</dependency>
+  	<dependency>
+  		<groupId>com.netflix.hystrix</groupId>
+  		<artifactId>hystrix-javanica</artifactId>
+  		<exclusions>
+  			<exclusion>
+  				<groupId>org.aspectj</groupId>
+  				<artifactId>aspectjrt</artifactId>
+  			</exclusion>
+  		</exclusions>
+  	</dependency>
+  	<dependency>
+  		<groupId>com.netflix.hystrix</groupId>
+  		<artifactId>hystrix-metrics-event-stream</artifactId>
+  	</dependency>
+  	<dependency>
+  		<groupId>io.reactivex</groupId>
+  		<artifactId>rxjava</artifactId>
+  	</dependency>
+  </dependencies>
+</project>

--- a/nutzboot-starter-hystrix/src/main/java/org/nutz/boot/starter/hystrix/HystrixAopStarter.java
+++ b/nutzboot-starter-hystrix/src/main/java/org/nutz/boot/starter/hystrix/HystrixAopStarter.java
@@ -1,0 +1,9 @@
+package org.nutz.boot.starter.hystrix;
+
+import org.nutz.ioc.loader.annotation.IocBean;
+
+@IocBean
+public class HystrixAopStarter {
+
+    protected static String PRE = "hystrix.";
+}

--- a/nutzboot-starter-hystrix/src/main/java/org/nutz/boot/starter/hystrix/HystrixCommandAopConfigure.java
+++ b/nutzboot-starter-hystrix/src/main/java/org/nutz/boot/starter/hystrix/HystrixCommandAopConfigure.java
@@ -1,0 +1,26 @@
+package org.nutz.boot.starter.hystrix;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+
+import org.nutz.aop.MethodInterceptor;
+import org.nutz.ioc.Ioc;
+import org.nutz.ioc.aop.SimpleAopMaker;
+import org.nutz.ioc.loader.annotation.IocBean;
+
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
+
+@IocBean(name="$aop_hystrix_command")
+public class HystrixCommandAopConfigure extends SimpleAopMaker<HystrixCommand> {
+
+    public List<? extends MethodInterceptor> makeIt(HystrixCommand t, Method method, Ioc ioc) {
+        try {
+            return Arrays.asList(new HystrixCommandInterceptor(t, method));
+        }
+        catch (NoSuchMethodException | SecurityException e) {
+            throw new RuntimeException(method.toString(), e);
+        }
+    }
+
+}

--- a/nutzboot-starter-hystrix/src/main/java/org/nutz/boot/starter/hystrix/HystrixCommandInterceptor.java
+++ b/nutzboot-starter-hystrix/src/main/java/org/nutz/boot/starter/hystrix/HystrixCommandInterceptor.java
@@ -1,0 +1,94 @@
+package org.nutz.boot.starter.hystrix;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import org.nutz.aop.InterceptorChain;
+import org.nutz.aop.MethodInterceptor;
+import org.nutz.lang.Strings;
+import org.nutz.lang.reflect.FastClassFactory;
+import org.nutz.lang.reflect.FastMethod;
+
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixException;
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixProperty;
+import com.netflix.hystrix.contrib.javanica.annotation.ObservableExecutionMode;
+import com.netflix.hystrix.contrib.javanica.command.GenericSetterBuilder;
+import com.netflix.hystrix.contrib.javanica.exception.HystrixCachingException;
+
+/**
+ * 
+ */
+public class HystrixCommandInterceptor implements MethodInterceptor {
+
+    protected HystrixCommand hystrixCommand;
+    protected String groupKey;
+    protected String commandKey;
+    protected FastMethod fallbackMethod;
+    protected String threadPoolKey;
+    protected HystrixProperty[] commandproperties;
+    protected HystrixProperty[] threadPoolProperties;
+    protected FastMethod defaultFallback;
+    protected Class<? extends Throwable>[] ignoreExceptions;
+    protected HystrixException[] raiseHystrixExceptions;
+    protected ObservableExecutionMode observableExecutionMode;
+    
+    
+    public HystrixCommandInterceptor(HystrixCommand hystrixCommand, Method method) throws NoSuchMethodException, SecurityException {
+        groupKey = Strings.sBlank(hystrixCommand.groupKey(), method.getDeclaringClass().getName());
+        commandKey = Strings.sBlank(hystrixCommand.commandKey(), method.getName());
+        if (!Strings.isBlank(hystrixCommand.fallbackMethod())) {
+            Method fb = method.getDeclaringClass().getMethod(hystrixCommand.fallbackMethod(), Throwable.class);
+            fallbackMethod = FastClassFactory.get(fb);
+        }
+        else if (!Strings.isBlank(hystrixCommand.defaultFallback())) {
+            Method fb = method.getDeclaringClass().getMethod(hystrixCommand.defaultFallback());
+            defaultFallback = FastClassFactory.get(fb);
+        }
+        threadPoolKey = hystrixCommand.threadPoolKey();
+        commandproperties = hystrixCommand.commandProperties();
+        threadPoolProperties = hystrixCommand.threadPoolProperties();
+        ignoreExceptions = hystrixCommand.ignoreExceptions();
+        raiseHystrixExceptions = hystrixCommand.raiseHystrixExceptions();
+        observableExecutionMode = hystrixCommand.observableExecutionMode();
+    }
+
+    public void filter(InterceptorChain chain) throws Throwable {
+        GenericSetterBuilder setter = GenericSetterBuilder.builder()
+                .commandKey(commandKey)
+                .groupKey(groupKey)
+                .threadPoolKey(threadPoolKey)
+                .threadPoolProperties(Arrays.asList(threadPoolProperties))
+                .commandProperties(Arrays.asList(commandproperties)).build();
+        com.netflix.hystrix.HystrixCommand<Object> cmd = new com.netflix.hystrix.HystrixCommand<Object>(setter.build()) {
+            
+            protected Object run() throws Exception {
+                try {
+                    return chain.doChain().getReturn();
+                }
+                catch (Throwable e) {
+                    for (Class<? extends Throwable> klass : ignoreExceptions) {
+                        if (klass.isAssignableFrom(e.getClass()))
+                            throw new HystrixCachingException(e);
+                    }
+                    if (e instanceof Exception)
+                        throw (Exception)e;
+                    throw new Exception(e);
+                }
+            }
+
+            protected Object getFallback() {
+                try {
+                    if (fallbackMethod != null)
+                        return fallbackMethod.invoke(chain.getCallingObj(), chain.getArgs());
+                    else if (defaultFallback != null)
+                        return defaultFallback.invoke(chain.getCallingObj()) ;
+                }
+                catch (Exception e) {
+                }
+                return null;
+            }
+        };
+        cmd.execute();
+    }
+}

--- a/nutzboot-starter-hystrix/src/main/java/org/nutz/boot/starter/hystrix/web/HystrixMetricsStreamServletFace.java
+++ b/nutzboot-starter-hystrix/src/main/java/org/nutz/boot/starter/hystrix/web/HystrixMetricsStreamServletFace.java
@@ -1,0 +1,25 @@
+package org.nutz.boot.starter.hystrix.web;
+
+import javax.servlet.Servlet;
+
+import org.nutz.boot.starter.WebServletFace;
+import org.nutz.ioc.loader.annotation.IocBean;
+
+import com.netflix.hystrix.contrib.metrics.eventstream.HystrixMetricsStreamServlet;
+
+@IocBean
+public class HystrixMetricsStreamServletFace implements WebServletFace {
+
+    public String getName() {
+        return "HystrixMetricsStreamServlet";
+    }
+
+    public String getPathSpec() {
+        return "/hystrix.stream";
+    }
+
+    public Servlet getServlet() {
+        return new HystrixMetricsStreamServlet();
+    }
+
+}

--- a/nutzboot-starter-hystrix/src/main/java/org/nutz/boot/starter/hystrix/web/HystrixRequestContextServletFilterFace.java
+++ b/nutzboot-starter-hystrix/src/main/java/org/nutz/boot/starter/hystrix/web/HystrixRequestContextServletFilterFace.java
@@ -1,0 +1,42 @@
+package org.nutz.boot.starter.hystrix.web;
+
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.DispatcherType;
+import javax.servlet.Filter;
+
+import org.nutz.boot.starter.WebFilterFace;
+import org.nutz.ioc.loader.annotation.IocBean;
+
+import com.netflix.hystrix.contrib.requestservlet.HystrixRequestContextServletFilter;
+
+@IocBean
+public class HystrixRequestContextServletFilterFace implements WebFilterFace {
+
+    public String getName() {
+        return "HystrixRequestContextServletFilter";
+    }
+
+    public String getPathSpec() {
+        return "/*";
+    }
+
+    public EnumSet<DispatcherType> getDispatches() {
+        return EnumSet.of(DispatcherType.REQUEST);
+    }
+
+    public Filter getFilter() {
+        return new HystrixRequestContextServletFilter();
+    }
+
+    public Map<String, String> getInitParameters() {
+        return new HashMap<>();
+    }
+
+    public int getOrder() {
+        return FilterOrder.HystrixRequestFilter;
+    }
+
+}

--- a/nutzboot-starter-hystrix/src/main/resources/META-INF/nutz/org.nutz.boot.starter.NbStarter
+++ b/nutzboot-starter-hystrix/src/main/resources/META-INF/nutz/org.nutz.boot.starter.NbStarter
@@ -1,0 +1,1 @@
+org.nutz.boot.starter.hystrix.HystrixAopStarter

--- a/nutzboot-starter/src/main/java/org/nutz/boot/starter/WebFilterFace.java
+++ b/nutzboot-starter/src/main/java/org/nutz/boot/starter/WebFilterFace.java
@@ -61,7 +61,8 @@ public interface WebFilterFace {
      *
      */
     public static interface FilterOrder {
-        // whale,druid,shiro,nutz
+        // hystrix,whale,druid,shiro,nutz
+        int HystrixRequestFilter = 5;
         int WhaleFilter = 10;
         int DruidFilter = 20;
         int ShiroFilter = 30;

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
 		<caffeine.version>2.6.1</caffeine.version>
 		<nutzboot.version>2.1-SNAPSHOT</nutzboot.version>
 		<feign.version>9.5.1</feign.version>
+		<hystrix.vesion>1.5.12</hystrix.vesion>
 	</properties>
 	<description>NutzBoot, micoservice base on Nutz</description>
 
@@ -84,6 +85,7 @@
 		<module>nutzboot-starter-cxf</module>
 		<module>nutzboot-starter-feign</module>
 		<module>nutzboot-starter-caffeine</module>
+		<module>nutzboot-starter-hystrix</module>
 	</modules>
 	<profiles>
 		<profile>
@@ -108,7 +110,7 @@
 			<dependency>
 				<groupId>org.nutz</groupId>
 				<artifactId>nutzboot-starter</artifactId>
-				<version>${project.version}</version>
+				<version>${nutzboot.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.nutz</groupId>
@@ -617,6 +619,11 @@
 			</dependency>
 			<dependency>
 				<groupId>org.nutz</groupId>
+				<artifactId>nutzboot-starter-hystrix</artifactId>
+				<version>${nutzboot.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.nutz</groupId>
 				<artifactId>nutzboot-starter-jetx</artifactId>
 				<version>${nutzboot.version}</version>
 			</dependency>
@@ -680,6 +687,37 @@
 				<groupId>io.github.openfeign</groupId>
 				<artifactId>feign-ribbon</artifactId>
 				<version>${feign.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.ow2.asm</groupId>
+				<artifactId>asm</artifactId>
+				<version>6.0</version>
+			</dependency>
+
+			<dependency>
+				<groupId>com.netflix.hystrix</groupId>
+				<artifactId>hystrix-request-servlet</artifactId>
+				<version>${hystrix.vesion}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.netflix.hystrix</groupId>
+				<artifactId>hystrix-core</artifactId>
+				<version>${hystrix.vesion}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.netflix.hystrix</groupId>
+				<artifactId>hystrix-javanica</artifactId>
+				<version>${hystrix.vesion}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.netflix.hystrix</groupId>
+				<artifactId>hystrix-metrics-event-stream</artifactId>
+				<version>${hystrix.vesion}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.reactivex</groupId>
+				<artifactId>rxjava</artifactId>
+				<version>1.1.1</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
支持的内容:
1. `@HystrixCommand`支持groupKey/commandKey/threadPoolKey/threadPoolProperties/commandproperties/ignoreExceptions/fallbackMethod/defaultFallback
2. 支持/hystrix.stream请求,可以通过hystrix-dashborad访问统计信息
3. 添加feign-hystrix的支持, 只需要添加依赖和设置@FeignInjec的fallback属性即可启用 