### PR TITLE
fix: 使用web.session.timeout替换原有的tomcat.session和undertow.session.

### DIFF
--- a/nutzboot-starter/nutzboot-starter-jetty/src/main/java/org/nutz/boot/starter/jetty/JettyStarter.java
+++ b/nutzboot-starter/nutzboot-starter-jetty/src/main/java/org/nutz/boot/starter/jetty/JettyStarter.java
@@ -75,6 +75,9 @@ public class JettyStarter implements ClassLoaderAware, IocAware, ServerFace, Lif
     @PropDoc(value = "表单最大尺寸", defaultValue = "1gb", type = "int")
     public static final String PROP_MAX_FORM_CONTENT_SIZE = PRE + "maxFormContentSize";
 
+    @PropDoc(value = "Session空闲时间,单位分钟", defaultValue = "30", type = "int")
+    public static final String PROP_SESSION_TIMEOUT = "web.session.timeout";
+
     @Inject
     private PropertiesProxy conf;
 
@@ -170,6 +173,7 @@ public class JettyStarter implements ClassLoaderAware, IocAware, ServerFace, Lif
         list.add("org.eclipse.jetty.annotations.AnnotationConfiguration");
         wac.setConfigurationClasses(list);
         wac.getServletContext().setExtendedListenerTypes(true);
+        wac.getSessionHandler().setMaxInactiveInterval(conf.getInt(PROP_SESSION_TIMEOUT, 30) * 60);
 
         // 设置一下额外的东西
         server.setAttribute("org.eclipse.jetty.server.Request.maxFormContentSize", getMaxFormContentSize());

--- a/nutzboot-starter/nutzboot-starter-tomcat/src/main/java/org/nutz/boot/starter/tomcat/TomcatStarter.java
+++ b/nutzboot-starter/nutzboot-starter-tomcat/src/main/java/org/nutz/boot/starter/tomcat/TomcatStarter.java
@@ -75,8 +75,8 @@ public class TomcatStarter implements ClassLoaderAware, ServerFace, LifeCycle, A
     @PropDoc(group = "tomcat", value = "上下文路径")
     public static final String PROP_CONTEXT_PATH = PRE + "contextPath";
 
-    @PropDoc(group = "tomcat", value = "session过期时间", defaultValue = "20")
-    public static final String PROP_SESSION = PRE + "session";
+    @PropDoc(value = "Session空闲时间,单位分钟", defaultValue = "30", type = "int")
+    public static final String PROP_SESSION_TIMEOUT = "web.session.timeout";
 
     @PropDoc(group = "tomcat", value = "静态文件路径", defaultValue = "static")
     public static final String PROP_STATIC_PATH = PRE + "staticPath";
@@ -200,7 +200,7 @@ public class TomcatStarter implements ClassLoaderAware, ServerFace, LifeCycle, A
         this.tomcatContext.setDelegate(false);
         this.tomcatContext.addLifecycleListener(new Tomcat.FixContextListener());
         this.tomcatContext.setParentClassLoader(classLoader);
-        this.tomcatContext.setSessionTimeout(getSessionTimeout());
+        this.tomcatContext.setSessionTimeout(getSessionTimeout() / 60);
         this.tomcatContext.addLifecycleListener(new StoreMergedWebXmlListener());
         StandardRoot sr = new StandardRoot(this.tomcatContext);
         sr.addPreResources(new ClasspathResourceSet(sr, "static/"));
@@ -387,7 +387,7 @@ public class TomcatStarter implements ClassLoaderAware, ServerFace, LifeCycle, A
     }
 
     public int getSessionTimeout() {
-        return conf.getInt(PROP_SESSION, 30);
+        return conf.getInt(PRE+"session", conf.getInt(PROP_SESSION_TIMEOUT, 30)) * 60;
     }
 
     public int getMaxThread() {

--- a/nutzboot-starter/nutzboot-starter-undertow/src/main/java/org/nutz/boot/starter/undertow/UndertowStarter.java
+++ b/nutzboot-starter/nutzboot-starter-undertow/src/main/java/org/nutz/boot/starter/undertow/UndertowStarter.java
@@ -66,8 +66,8 @@ public class UndertowStarter implements ClassLoaderAware, IocAware, ServerFace, 
 	@PropDoc(group = "undertow", value = "上下文路径", defaultValue = "/")
 	public static final String PROP_CONTEXT_PATH = PRE + "contextPath";
 
-	@PropDoc(group = "undertow", value = "session过期时间,单位分钟", defaultValue = "30", type="int")
-	public static final String PROP_SESSION = PRE + "session";
+    @PropDoc(value = "Session空闲时间,单位分钟", defaultValue = "30", type = "int")
+    public static final String PROP_SESSION_TIMEOUT = "web.session.timeout";
 
 	@PropDoc(group = "undertow", value = "静态文件路径", defaultValue = "static/")
 	public static final String PROP_STATIC_PATH = PRE + "staticPath";
@@ -259,7 +259,7 @@ public class UndertowStarter implements ClassLoaderAware, IocAware, ServerFace, 
 	}
 
 	public int getSessionTimeout() {
-		return conf.getInt(PROP_SESSION, 20) * 60;
+	    return conf.getInt(PRE+"session", conf.getInt(PROP_SESSION_TIMEOUT, 30)) * 60;
 	}
 
 }


### PR DESCRIPTION
PS: jetty原本就没有jetty.session,所以不存在替换问题

fix: issue #106