### PR TITLE
fix:修复正确的allowCommandLineProperties逻辑

### DIFF
--- a/nutzboot-core/src/main/java/org/nutz/boot/config/impl/AbstractConfigureLoader.java
+++ b/nutzboot-core/src/main/java/org/nutz/boot/config/impl/AbstractConfigureLoader.java
@@ -70,7 +70,12 @@ public abstract class AbstractConfigureLoader implements ConfigureLoader, LifeCy
      */
     protected void parseCommandLineArgs(PropertiesProxy conf, String[] args) {
     	for (int i=0;i< args.length;i++) {
-    		String arg = args[i];
+            String arg = args[i];
+            if (arg.startsWith("-D")) {
+                String[] tmp = arg.split("=");
+                addCommandLineArg(conf, tmp[0].substring(2), tmp.length == 1 ? "true" : tmp[1]);
+                continue;
+            }
     		if (!arg.startsWith("--")) {
     			continue;
     		}

--- a/nutzboot-core/src/main/java/org/nutz/boot/config/impl/PropertiesConfigureLoader.java
+++ b/nutzboot-core/src/main/java/org/nutz/boot/config/impl/PropertiesConfigureLoader.java
@@ -55,9 +55,8 @@ public class PropertiesConfigureLoader extends AbstractConfigureLoader {
         		conf.put("nutz.profiles.active", tmp.remove("nutz.profiles.active"));
         	}
         }
-        if (allowCommandLineProperties) {
-        	conf.putAll(System.getProperties());
-        }
+        // 默认加载SystemProperties,这样可以兼容以前的默认配置情况 要不要加个配置项?
+        conf.putAll(System.getProperties());
         // 加载指定profile,如果有的话
         if (conf.has("nutz.profiles.active")) {
         	String profile = conf.get("nutz.profiles.active");
@@ -82,7 +81,7 @@ public class PropertiesConfigureLoader extends AbstractConfigureLoader {
             });
         }
         // 把命令行参数放进去
-        if (tmp.size() > 0) {
+        if (allowCommandLineProperties && tmp.size() > 0) {
         	conf.putAll(tmp.toMap());
         }
         if (Strings.isBlank(conf.get("app.build.version"))) {

--- a/nutzboot-core/src/main/java/org/nutz/boot/config/impl/PropertiesConfigureLoader.java
+++ b/nutzboot-core/src/main/java/org/nutz/boot/config/impl/PropertiesConfigureLoader.java
@@ -49,7 +49,7 @@ public class PropertiesConfigureLoader extends AbstractConfigureLoader {
         }
         // 也许命令行里面指定了profile,需要提前load进来
         PropertiesProxy tmp = new PropertiesProxy();
-        if (args != null) {
+        if (allowCommandLineProperties && args != null) {
         	parseCommandLineArgs(tmp, args);
         	if (tmp.has("nutz.profiles.active")) {
         		conf.put("nutz.profiles.active", tmp.remove("nutz.profiles.active"));


### PR DESCRIPTION
以前的allowCommandLineProperties逻辑好像不对?
另外也没有解析-Dxxx.xxx=xx格式的配置项
