### PR TITLE
Remove redundant dependencies

### DIFF
--- a/nutzboot-starter/nutzboot-starter-seata/pom.xml
+++ b/nutzboot-starter/nutzboot-starter-seata/pom.xml
@@ -20,6 +20,12 @@
 			<groupId>io.seata</groupId>
 			<artifactId>seata-spring</artifactId>
 			<version>${seata.version}</version>
+			<exclusions>
+				<exclusion>
+				    <groupId>io.seata</groupId>
+				    <artifactId>seata-serializer-all</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>com.alibaba</groupId>


### PR DESCRIPTION
Hi, I am a user of project **_org.nutz:nutzboot-starter-seata:2.4.3-SNAPSHOT_**. I found that its pom file introduced **_48_** dependencies. However, among them, **_16_** libraries (**_33%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. Finally, it can help enable advanced scenarios for users of your package. 
This PR helps **_org.nutz:nutzboot-starter-seata:2.4.3-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
com.google.protobuf:protobuf-java:jar:3.7.1:compile
io.seata:seata-serializer-seata:jar:1.2.0:compile
io.seata:seata-serializer-hessian:jar:1.2.0:compile
com.esotericsoftware:kryo:jar:4.0.2:compile
io.seata:seata-serializer-fst:jar:1.2.0:compile
de.ruedigermoeller:fst:jar:2.57:compile
io.seata:seata-serializer-all:jar:1.2.0:compile
io.seata:seata-serializer-protobuf:jar:1.2.0:compile
com.esotericsoftware:reflectasm:jar:1.11.3:compile
javax.servlet:javax.servlet-api:jar:3.1.0:compile
com.esotericsoftware:minlog:jar:1.3.0:compile
io.seata:seata-serializer-kryo:jar:1.2.0:compile
de.javakaffee:kryo-serializers:jar:0.42:compile
org.javassist:javassist:jar:3.24.0-GA:compile
com.caucho:hessian:jar:4.0.63:compile
org.objenesis:objenesis:jar:2.5.1:compile
</code></pre>